### PR TITLE
Main outlet padding top remove

### DIFF
--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -6,10 +6,6 @@
   padding-right: 10vw;
 }
 
-#main-outlet {
-  padding-top: 6em;
-}
-
 .d-header {
   height: 60px;
 }


### PR DESCRIPTION
The padding top 6em is too large. The default 1.8em is enough.